### PR TITLE
Support downloading mp3 audios via AUDIO_FORMAT config

### DIFF
--- a/AutoDefineAddon/autodefine.py
+++ b/AutoDefineAddon/autodefine.py
@@ -59,6 +59,7 @@ AUDIO = get_config_value(section, " 2. AUDIO", False)
 AUDIO_FIELD = get_config_value(section, " 3. AUDIO_FIELD", 2)
 PHONETICS = get_config_value(section, " 4. PHONETICS", False)
 PHONETICS_FIELD = get_config_value(section, " 5. PHONETICS_FIELD", 3)
+AUDIO_FORMAT = get_config_value(section, " 6. AUDIO_FORMAT", "ogg")
 
 section = '4. image'
 OPEN_IMAGES_IN_BROWSER = get_config_value(section, " 1. OPEN_IMAGES_IN_BROWSER", False)
@@ -369,7 +370,7 @@ def fill_audio_dict_prioritized(audio_dict, pronunciations, wordform):
     for corpus_tag in CORPUS_TAGS_PRIORITIZED:
         for pronunciation in pronunciations:
             if corpus_tag == pronunciation["prefix"]:
-                audio_url = pronunciation["url"]
+                audio_url = pronunciation["mp3"] if AUDIO_FORMAT.lower() == "mp3" else pronunciation["ogg"]
 
                 audio_name = audio_url.split('/')[-1]
 

--- a/AutoDefineAddon/config.json
+++ b/AutoDefineAddon/config.json
@@ -15,7 +15,8 @@
     " 2. AUDIO": false,
     " 3. AUDIO_FIELD": 2,
     " 4. PHONETICS": false,
-    " 5. PHONETICS_FIELD": 3
+    " 5. PHONETICS_FIELD": 3,
+    " 6. AUDIO_FORMAT": "ogg"
   },
   "4. image": {
     " 1. OPEN_IMAGES_IN_BROWSER": false,

--- a/AutoDefineAddon/config.md
+++ b/AutoDefineAddon/config.md
@@ -11,6 +11,7 @@ Config structure have recently changed, if you updated the addon press Restore D
 * `CORPUS`: 'American' or 'British' English
 * `AUDIO`: Add audio of pronunciation to AUDIO_FIELD
 * `AUDIO_FIELD`: Index of field to insert audio into
+* `AUDIO_FORMAT`: Preferred audio format (ogg or mp3)
 * `PHONETICS`: Add International Phonetic Alphabet to PHONETICS_FIELD
 * `PHONETICS_FIELD`: Index of field to insert phonetics into
 * `OPEN_IMAGES_IN_BROWSER`: Open a browser tab with an image search for the same word?

--- a/AutoDefineAddon/oxford.py
+++ b/AutoDefineAddon/oxford.py
@@ -62,8 +62,10 @@ class Word(object):
 
     br_pronounce_selector = '[geo=br] .phon'
     am_pronounce_selector = '[geo=n_am] .phon'
-    br_pronounce_audio_selector = '[geo=br] [data-src-ogg]'
-    am_pronounce_audio_selector = '[geo=n_am] [data-src-ogg]'
+    br_pronounce_audio_ogg_selector = '[geo=br] [data-src-ogg]'
+    am_pronounce_audio_ogg_selector = '[geo=n_am] [data-src-ogg]'
+    br_pronounce_audio_mp3_selector = '[geo=br] [data-src-mp3]'
+    am_pronounce_audio_mp3_selector = '[geo=n_am] [data-src-mp3]'
 
     definition_body_selector = '.senses_multiple'
     definition_body_selector_single = '.sense_single'
@@ -230,8 +232,8 @@ class Word(object):
         if cls.soup_data is None:
             return None
 
-        britain = {'prefix': None, 'ipa': None, 'url': None}
-        america = {'prefix': None, 'ipa': None, 'url': None}
+        britain = {'prefix': None, 'ipa': None, 'ogg': None, 'mp3': None}
+        america = {'prefix': None, 'ipa': None, 'ogg': None, 'mp3': None}
 
         try:
             britain_pron_tag = cls.soup_data.select(cls.br_pronounce_selector)[0]
@@ -245,16 +247,18 @@ class Word(object):
             pass
 
         try:
-            britain['url'] = cls.soup_data.select(cls.br_pronounce_audio_selector)[0].attrs['data-src-ogg']
-            america['url'] = cls.soup_data.select(cls.am_pronounce_audio_selector)[0].attrs['data-src-ogg']
+            britain['ogg'] = cls.soup_data.select(cls.br_pronounce_audio_ogg_selector)[0].attrs['data-src-ogg']
+            america['ogg'] = cls.soup_data.select(cls.am_pronounce_audio_ogg_selector)[0].attrs['data-src-ogg']
+            britain['mp3'] = cls.soup_data.select(cls.br_pronounce_audio_mp3_selector)[0].attrs['data-src-mp3']
+            america['mp3'] = cls.soup_data.select(cls.am_pronounce_audio_mp3_selector)[0].attrs['data-src-mp3']
         except IndexError:
             pass
 
-        if britain['prefix'] == None and britain['url'] is not None:
-            britain['prefix'] = cls.get_prefix_from_filename(britain['url'])
+        if britain['prefix'] is None and (britain['ogg'] or britain['mp3']):
+            britain['prefix'] = cls.get_prefix_from_filename(britain['ogg']) or cls.get_prefix_from_filename(britain['mp3'])
 
-        if america['prefix'] == None and america['url'] is not None:
-            america['prefix'] = cls.get_prefix_from_filename(america['url'])
+        if america['prefix'] is None and (america['ogg'] or america['mp3']):
+            america['prefix'] = cls.get_prefix_from_filename(america['ogg']) or cls.get_prefix_from_filename(america['mp3'])
 
         return [britain, america]
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -29,7 +29,8 @@ config = \
             " 2. AUDIO": True,
             " 3. AUDIO_FIELD": 2,
             " 4. PHONETICS": True,
-            " 5. PHONETICS_FIELD": 3
+            " 5. PHONETICS_FIELD": 3,
+            " 6. AUDIO_FORMAT": "mp3"
         },
         "4. image": {
             " 1. OPEN_IMAGES_IN_BROWSER": False,


### PR DESCRIPTION
### Notes
OGG format is not supported on iOS. This change will allow users to download MP3 files to play on iOS devices.

I added the configuration key as " 6. AUDIO_FORMAT". It's a bit out of order, but is backwards compatible.
```
    "3. audio and phonetics": {
        " 1. CORPUS": "American",
        " 2. AUDIO": true,
        " 3. AUDIO_FIELD": 2,
        " 4. PHONETICS": true,
        " 5. PHONETICS_FIELD": 3,
        " 6. AUDIO_FORMAT": "mp3"
    },
```

Help text:
```
AUDIO: Add audio of pronunciation to AUDIO_FIELD
AUDIO_FIELD: Index of field to insert audio into
AUDIO_FORMAT: Preferred audio format (ogg or mp3)
```

### Issue
https://github.com/artyompetrov/AutoDefine_oxfordlearnersdictionaries/issues/12

### Testing
I'm working on macOS and cannot run the tests. This seems to be a problem with pytest-anki, but I'm not sure.

If someone can help run the tests, that'd be great. Otherwise, I'll try to get my hands on some Linux machines to see if I can get the tests to run there.