### PR TITLE
Workaround "Remote end closed connection without response" error when downloading audio

### DIFF
--- a/AutoDefineAddon/autodefine.py
+++ b/AutoDefineAddon/autodefine.py
@@ -386,7 +386,7 @@ def fill_audio_dict_prioritized(audio_dict, pronunciations, wordform):
                     if not os.path.exists(audio_path):
                         req = requests.Session()
                         req.cookies.set_policy(BlockAll())
-                        response = req.get(audio_url, timeout=5, headers={'User-agent': 'mother animal'})
+                        response = req.get(audio_url, timeout=5, headers={'User-agent': 'Mozilla/5.0'})
                         with open(audio_path, 'wb') as f:
                             f.write(response.content)
                     audio_dict[audio_name] = {'wordform': [wordform], "audio_name": audio_name}


### PR DESCRIPTION
Oxford recently started aborting connections for audio downloads. Changing the User-agent header to "Mozilla/5.0" fixed the issue. I suspect Oxford just block listed 'mother animal' browers :-) .

Stack trace:
```
Traceback (most recent call last):
  File "/Users/vy/Library/Application Support/Anki2/addons21/570730390/autodefine.py", line 415, in get_data_with_exception_handling
    get_data(editor)
  File "/Users/vy/Library/Application Support/Anki2/addons21/570730390/autodefine.py", line 234, in get_data
    audio = get_audio(words_info)
  File "/Users/vy/Library/Application Support/Anki2/addons21/570730390/autodefine.py", line 359, in get_audio
    fill_audio_dict_prioritized(audio_dict, pronunciations, wordform)
  File "/Users/vy/Library/Application Support/Anki2/addons21/570730390/autodefine.py", line 389, in fill_audio_dict_prioritized
    response = req.get(audio_url, timeout=5, headers={'User-agent': 'mother animal'})
  File "requests.sessions", line 602, in get
  File "requests.sessions", line 589, in request
  File "requests.sessions", line 703, in send
  File "requests.adapters", line 501, in send
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```