### PR TITLE
docs: clarify plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ Only tested on Anki 2.1.x.
 
 [Anki Add-On page](https://ankiweb.net/shared/info/570730390)
 
+## Configuration
+
+1. Install the add-on and restart Anki.
+2. Open **Tools → Add-ons → AutoDefine Oxford Learner's Dictionaries → Config** to adjust settings.
+3. With `USE_DEFAULT_TEMPLATE` enabled (default) the add-on creates a note type named **AutoDefineOxfordLearnersDictionary** and switches to it automatically. This note type already contains fields for the word, definition, audio, phonetics, verb forms and image, so no manual setup is required.
+4. If you prefer to use your own note type, disable `USE_DEFAULT_TEMPLATE` and set the field numbers to match your layout. Field numbers are zero‑based: the first field is `0`, the second is `1`, etc.
+   - `SOURCE_FIELD` – field containing the word to define.
+   - `DEFINITION_FIELD`, `AUDIO_FIELD`, `PHONETICS_FIELD`, `VERB_FORMS_FIELD`, `IMAGE_FIELD` – fields that will receive generated content.
+5. Click **Restore Defaults** in the configuration dialog if you run into errors or want to start over.
+
+For a full list of options see [AutoDefineAddon/config.md](AutoDefineAddon/config.md).
+
+## Usage
+
+Enter a word in the source field and click the add-on button or press `Ctrl+Alt+E` (default). The add-on will fill the configured fields with definition, audio and other information.
+
 ## License & Credits
 
 Code licensed under GPLv2


### PR DESCRIPTION
## Summary
- document add-on configuration steps in README
- explain default template and zero-based field numbers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'anki')*

------
https://chatgpt.com/codex/tasks/task_e_689ea12dd0fc833098483d0998988741